### PR TITLE
解决请求成功和失败时服务器返回的data数据的结构不一样的问题（Gson自定义解析）

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ## 版本说明
 
 ### 当前版本
-[![release](https://img.shields.io/badge/release-V2.1.2-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
+[![release](https://img.shields.io/badge/release-V2.1.7-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
 
 **[历史版本，点我、点我、点我>>](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)**
 
@@ -75,7 +75,7 @@
 ### build.gradle设置
 ```
 dependencies {
- compile 'com.zhouyou:rxeasyhttp:2.1.5'
+ compile 'com.zhouyou:rxeasyhttp:2.1.7'
 }
 ```
 想查看所有版本，请点击下面地址。

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ## 版本说明
 
 ### 当前版本
-[![release](https://img.shields.io/badge/release-V2.1.5-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
+[![release](https://img.shields.io/badge/release-V2.1.2-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
 
 **[历史版本，点我、点我、点我>>](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)**
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ## 版本说明
 
 ### 当前版本
-[![release](https://img.shields.io/badge/release-V2.1.7-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
+[![release](https://img.shields.io/badge/release-V2.1.5-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
 
 **[历史版本，点我、点我、点我>>](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)**
 
@@ -75,7 +75,7 @@
 ### build.gradle设置
 ```
 dependencies {
- compile 'com.zhouyou:rxeasyhttp:2.1.7'
+ implementation 'com.zhouyou:rxeasyhttp:2.1.5'
 }
 ```
 想查看所有版本，请点击下面地址。

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@
 ## 版本说明
 
 ### 当前版本
-[![release](https://img.shields.io/badge/release-V2.1.2-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
+[![release](https://img.shields.io/badge/release-V2.1.5-orange.svg)](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)
 
 **[历史版本，点我、点我、点我>>](https://github.com/zhou-you/RxEasyHttp/blob/master/update.md)**
 

--- a/rxeasyhttp/build.gradle
+++ b/rxeasyhttp/build.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'com.android.library'
-//apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileSdkVersion 29
@@ -46,4 +45,3 @@ dependencies {
     api 'com.squareup.retrofit2:converter-gson:2.5.0'
     api 'com.squareup.retrofit2:adapter-rxjava2:2.5.0'
 }
-apply from: '../bintray.gradle'

--- a/rxeasyhttp/build.gradle
+++ b/rxeasyhttp/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 //apply plugin: 'me.tatarka.retrolambda'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '25.0.0'
+    compileSdkVersion 29
+    buildToolsVersion '30.0.2'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 23
+        targetSdkVersion 29
         versionCode 4
         versionName "2.1.6"
 
@@ -31,19 +31,19 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    api fileTree(include: ['*.jar'], dir: 'libs')
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13'
     //第三方依赖库
-    compile 'com.squareup.okhttp3:logging-interceptor:3.12.2'
-    compile 'com.squareup.okhttp3:okhttp:3.12.2'
-    compile 'com.jakewharton:disklrucache:2.0.2'
-    compile 'io.reactivex.rxjava2:rxjava:2.2.10'
-    compile 'io.reactivex.rxjava2:rxandroid:2.1.1'
-    compile 'com.squareup.retrofit2:retrofit:2.5.0'
-    compile 'com.squareup.retrofit2:converter-gson:2.5.0'
-    compile 'com.squareup.retrofit2:adapter-rxjava2:2.5.0'
+    api 'com.squareup.okhttp3:logging-interceptor:3.12.2'
+    api 'com.squareup.okhttp3:okhttp:3.12.2'
+    api 'com.jakewharton:disklrucache:2.0.2'
+    api 'io.reactivex.rxjava2:rxjava:2.2.10'
+    api 'io.reactivex.rxjava2:rxandroid:2.1.1'
+    api 'com.squareup.retrofit2:retrofit:2.5.0'
+    api 'com.squareup.retrofit2:converter-gson:2.5.0'
+    api 'com.squareup.retrofit2:adapter-rxjava2:2.5.0'
 }
 apply from: '../bintray.gradle'

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/exception/ApiException.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/exception/ApiException.java
@@ -21,6 +21,8 @@ import android.net.ParseException;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializer;
 import com.google.gson.JsonSyntaxException;
+import com.zhouyou.http.EasyHttp;
+import com.zhouyou.http.R;
 import com.zhouyou.http.model.ApiResult;
 
 import org.apache.http.conn.ConnectTimeoutException;
@@ -121,31 +123,32 @@ public class ApiException extends Exception {
                 || e instanceof NotSerializableException
                 || e instanceof ParseException) {
             ex = new ApiException(e, ERROR.PARSE_ERROR);
-            ex.message = "解析错误";
+
+            ex.message = EasyHttp.getContext().getString(R.string.parsing_error);
             return ex;
         } else if (e instanceof ClassCastException) {
             ex = new ApiException(e, ERROR.CAST_ERROR);
-            ex.message = "类型转换错误";
+            ex.message = EasyHttp.getContext().getString(R.string.type_conversion_error);
             return ex;
         } else if (e instanceof ConnectException) {
             ex = new ApiException(e, ERROR.NETWORD_ERROR);
-            ex.message = "连接失败";
+            ex.message = EasyHttp.getContext().getString(R.string.connection_failed);
             return ex;
         } else if (e instanceof javax.net.ssl.SSLHandshakeException) {
             ex = new ApiException(e, ERROR.SSL_ERROR);
-            ex.message = "证书验证失败";
+            ex.message = EasyHttp.getContext().getString(R.string.certificate_verification_failed);
             return ex;
         } else if (e instanceof ConnectTimeoutException) {
             ex = new ApiException(e, ERROR.TIMEOUT_ERROR);
-            ex.message = "连接超时";
+            ex.message = EasyHttp.getContext().getString(R.string.time_out);
             return ex;
         } else if (e instanceof java.net.SocketTimeoutException) {
             ex = new ApiException(e, ERROR.TIMEOUT_ERROR);
-            ex.message = "连接超时";
+            ex.message = EasyHttp.getContext().getString(R.string.time_out);
             return ex;
         } else if (e instanceof UnknownHostException) {
             ex = new ApiException(e, ERROR.UNKNOWNHOST_ERROR);
-            ex.message = "无法解析该域名";
+            ex.message = EasyHttp.getContext().getString(R.string.cannot_be_resolved);
             return ex;
         } else if (e instanceof NullPointerException) {
             ex = new ApiException(e, ERROR.NULLPOINTER_EXCEPTION);
@@ -153,7 +156,7 @@ public class ApiException extends Exception {
             return ex;
         } else {
             ex = new ApiException(e, ERROR.UNKNOWN);
-            ex.message = "未知错误";
+            ex.message = EasyHttp.getContext().getString(R.string.unknown_error);
             return ex;
         }
     }

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/func/ApiResultFunc.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/func/ApiResultFunc.java
@@ -16,20 +16,12 @@
 
 package com.zhouyou.http.func;
 
-import android.text.TextUtils;
-
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.zhouyou.http.gson.ZGsonBuilder;
 import com.zhouyou.http.model.ApiResult;
-import com.zhouyou.http.utils.Utils;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.io.IOException;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
-import java.util.List;
 
 import io.reactivex.annotations.NonNull;
 import io.reactivex.functions.Function;
@@ -42,48 +34,23 @@ import okhttp3.ResponseBody;
  * 日期： 2017/3/15 16:52 <br>
  * 版本： v1.0<br>
  */
-@SuppressWarnings("unchecked")
 public class ApiResultFunc<T> implements Function<ResponseBody, ApiResult<T>> {
     protected Type type;
     protected Gson gson;
 
     public ApiResultFunc(Type type) {
-        gson = new GsonBuilder()
-                .excludeFieldsWithModifiers(Modifier.FINAL, Modifier.TRANSIENT, Modifier.STATIC)
-                .serializeNulls()
-                .create();
         this.type = type;
+        gson = ZGsonBuilder.gsonBuilder2(type).create();
     }
 
     @Override
-    public ApiResult<T> apply(@NonNull ResponseBody responseBody) throws Exception {
+    public ApiResult<T> apply(@NonNull ResponseBody responseBody) {
         ApiResult<T> apiResult = new ApiResult<>();
         apiResult.setCode(-1);
 
         try {
             String json = responseBody.string();
-            final ApiResult result = parseApiResult(json, apiResult);
-
-            if (result == null) {
-                apiResult.setMsg("data is null");
-            } else {
-                apiResult.setCode(result.getCode());
-                apiResult.setMsg(result.getMsg());
-
-                final Class<T> clazz = Utils.getClass(type, 0);
-                //增加是List<String>判断错误的问题
-                if (apiResult.isOk()) {
-                    if (!List.class.isAssignableFrom(clazz) && clazz.equals(String.class)) {
-                        apiResult.setData((T) json);
-                        apiResult.setCode(0);
-                    } else {
-                        apiResult = gson.fromJson(json, type);
-                    }
-                }
-            }
-        } catch (JSONException e) {
-            e.printStackTrace();
-            apiResult.setMsg(e.getMessage());
+            return gson.fromJson(json, type);
         } catch (IOException e) {
             e.printStackTrace();
             apiResult.setMsg(e.getMessage());
@@ -93,22 +60,126 @@ public class ApiResultFunc<T> implements Function<ResponseBody, ApiResult<T>> {
         } finally {
             responseBody.close();
         }
+
         return apiResult;
     }
 
-    private ApiResult parseApiResult(String json, ApiResult apiResult) throws JSONException {
-        if (TextUtils.isEmpty(json))
-            return null;
-        JSONObject jsonObject = new JSONObject(json);
-        if (jsonObject.has("code")) {
-            apiResult.setCode(jsonObject.getInt("code"));
-        }
-        if (jsonObject.has("data")) {
-            apiResult.setData(jsonObject.getString("data"));
-        }
-        if (jsonObject.has("msg")) {
-            apiResult.setMsg(jsonObject.getString("msg"));
-        }
-        return apiResult;
-    }
 }
+
+
+
+
+///*
+// * Copyright (C) 2017 zhouyou(478319399@qq.com)
+// *
+// * Licensed under the Apache License, Version 2.0 (the "License");
+// * you may not use this file except in compliance with the License.
+// * You may obtain a copy of the License at
+// *
+// *       http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//
+//package com.zhouyou.http.func;
+//
+//import android.text.TextUtils;
+//
+//import com.google.gson.Gson;
+//import com.google.gson.GsonBuilder;
+//import com.zhouyou.http.model.ApiResult;
+//import com.zhouyou.http.utils.Utils;
+//
+//import org.json.JSONException;
+//import org.json.JSONObject;
+//
+//import java.io.IOException;
+//import java.lang.reflect.Modifier;
+//import java.lang.reflect.Type;
+//import java.util.List;
+//
+//import io.reactivex.annotations.NonNull;
+//import io.reactivex.functions.Function;
+//import okhttp3.ResponseBody;
+//
+//
+///**
+// * <p>描述：定义了ApiResult结果转换Func</p>
+// * 作者： zhouyou<br>
+// * 日期： 2017/3/15 16:52 <br>
+// * 版本： v1.0<br>
+// */
+//@SuppressWarnings("unchecked")
+//public class ApiResultFunc<T> implements Function<ResponseBody, ApiResult<T>> {
+//    protected Type type;
+//    protected Gson gson;
+//
+//    public ApiResultFunc(Type type) {
+//        gson = new GsonBuilder()
+//                .excludeFieldsWithModifiers(Modifier.FINAL, Modifier.TRANSIENT, Modifier.STATIC)
+//                .serializeNulls()
+//                .create();
+//        this.type = type;
+//    }
+//
+//    @Override
+//    public ApiResult<T> apply(@NonNull ResponseBody responseBody) {
+//        ApiResult<T> apiResult = new ApiResult<>();
+//        apiResult.setCode(-1);
+//
+//        try {
+//            String json = responseBody.string();
+//            final ApiResult result = parseApiResult(json, apiResult);
+//
+//            if (result == null) {
+//                apiResult.setMsg("data is null");
+//            } else {
+//                apiResult.setCode(result.getCode());
+//                apiResult.setMsg(result.getMsg());
+//
+//                final Class<T> clazz = Utils.getClass(type, 0);
+//                //增加是List<String>判断错误的问题
+//                if (apiResult.isOk()) {
+//                    if (!List.class.isAssignableFrom(clazz) && clazz.equals(String.class)) {
+//                        apiResult.setData((T) json);
+//                        apiResult.setCode(0);
+//                    } else {
+//                        apiResult = gson.fromJson(json, type);
+//                    }
+//                }
+//            }
+//        } catch (JSONException e) {
+//            e.printStackTrace();
+//            apiResult.setMsg(e.getMessage());
+//        } catch (IOException e) {
+//            e.printStackTrace();
+//            apiResult.setMsg(e.getMessage());
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            apiResult.setMsg(e.getMessage());
+//        } finally {
+//            responseBody.close();
+//        }
+//        return apiResult;
+//    }
+//
+//    private ApiResult parseApiResult(String json, ApiResult apiResult) throws JSONException {
+//        if (TextUtils.isEmpty(json))
+//            return null;
+//        JSONObject jsonObject = new JSONObject(json);
+//        if (jsonObject.has("code")) {
+//            apiResult.setCode(jsonObject.getInt("code"));
+//        }
+//        if (jsonObject.has("message")) {
+//            apiResult.setMsg(jsonObject.getString("message"));
+//        }
+////        if (jsonObject.has("data")) {
+////            apiResult.setData(jsonObject.getString("data"));
+////        }
+//        return apiResult;
+//    }
+//}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/BigDecimalTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/BigDecimalTypeAdapter.java
@@ -1,0 +1,36 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+class BigDecimalTypeAdapter extends TypeAdapter<BigDecimal> {
+
+    @Override
+    public void write(JsonWriter out, BigDecimal value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public BigDecimal read(JsonReader in) throws IOException {
+
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return BigDecimal.valueOf(0);
+        }
+
+        try {
+            return BigDecimal.valueOf(Double.parseDouble(in.nextString()));
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return BigDecimal.valueOf(0);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return BigDecimal.valueOf(0);
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/BigIntegerTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/BigIntegerTypeAdapter.java
@@ -1,0 +1,36 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.math.BigInteger;
+
+class BigIntegerTypeAdapter extends TypeAdapter<BigInteger> {
+
+    @Override
+    public void write(JsonWriter out, BigInteger value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public BigInteger read(JsonReader in) throws IOException {
+
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return BigInteger.valueOf(0);
+        }
+
+        try {
+            return new BigInteger(in.nextString());
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return BigInteger.valueOf(0);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return BigInteger.valueOf(0);
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/BoolTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/BoolTypeAdapter.java
@@ -1,0 +1,31 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class BoolTypeAdapter extends TypeAdapter<Boolean> {
+
+    @Override
+    public void write(JsonWriter out, Boolean value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Boolean read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return false;
+        }
+
+        try {
+            return in.nextBoolean();
+        } catch (IOException e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ByteTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ByteTypeAdapter.java
@@ -1,0 +1,34 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class ByteTypeAdapter extends TypeAdapter<Byte> {
+
+    @Override
+    public void write(JsonWriter out, Byte value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Byte read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return 0;
+        }
+
+        try {
+            return Byte.valueOf(in.nextString());
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0;
+        }catch (IOException e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ChatTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ChatTypeAdapter.java
@@ -1,0 +1,34 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class ChatTypeAdapter extends TypeAdapter<Character> {
+
+    @Override
+    public void write(JsonWriter out, Character value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Character read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL) || !in.peek().equals(JsonToken.NUMBER)) {
+            in.skipValue();
+            return '0';
+        }
+
+        try {
+            return (char) in.nextInt();
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return '0';
+        } catch (IOException e) {
+            e.printStackTrace();
+            return '0';
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/DoubleTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/DoubleTypeAdapter.java
@@ -1,0 +1,34 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class DoubleTypeAdapter extends TypeAdapter<Double> {
+
+    @Override
+    public void write(JsonWriter out, Double value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Double read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return 0d;
+        }
+
+        try {
+            return Double.parseDouble(in.nextString());
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0d;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return 0d;
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/FloatTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/FloatTypeAdapter.java
@@ -1,0 +1,33 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class FloatTypeAdapter extends TypeAdapter<Float> {
+
+    @Override
+    public void write(JsonWriter out, Float value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Float read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return 0f;
+        }
+        try {
+            return Float.parseFloat(in.nextString());
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0f;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return 0f;
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/IntegerTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/IntegerTypeAdapter.java
@@ -1,0 +1,35 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class IntegerTypeAdapter extends TypeAdapter<Integer> {
+
+    @Override
+    public void write(JsonWriter out, Integer value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Integer read(JsonReader in) throws IOException {
+
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return 0;
+        }
+
+        try {
+            return Integer.parseInt(in.nextString());
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ListJsonDeserializer.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ListJsonDeserializer.java
@@ -1,0 +1,20 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class ListJsonDeserializer implements JsonDeserializer<List> {
+
+    @Override
+    public List deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (json.isJsonArray()) {
+            return ZGsonBuilder.gsonBuilder().create().fromJson(json, typeOfT);
+        }
+        return null;
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/LongTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/LongTypeAdapter.java
@@ -1,0 +1,34 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class LongTypeAdapter extends TypeAdapter<Long> {
+
+    @Override
+    public void write(JsonWriter out, Long value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Long read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return 0L;
+        }
+
+        try {
+            return Long.parseLong(in.nextString());
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0L;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return 0L;
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ObjectJsonDeserializer.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ObjectJsonDeserializer.java
@@ -1,0 +1,18 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+
+import java.lang.reflect.Type;
+
+public class ObjectJsonDeserializer<T> implements JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+        if (json.isJsonObject()) {
+            return ZGsonBuilder.gsonBuilder().create().fromJson(json, typeOfT);
+        }
+        return null;
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ShortTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ShortTypeAdapter.java
@@ -1,0 +1,34 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class ShortTypeAdapter extends TypeAdapter<Short> {
+
+    @Override
+    public void write(JsonWriter out, Short value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public Short read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return 0;
+        }
+
+        try {
+            return Short.parseShort(in.nextString());
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return 0;
+        } catch (IOException e) {
+            e.printStackTrace();
+            return 0;
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/StringTypeAdapter.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/StringTypeAdapter.java
@@ -1,0 +1,34 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+
+public class StringTypeAdapter extends TypeAdapter<String> {
+
+    @Override
+    public void write(JsonWriter out, String value) throws IOException {
+        out.value(value);
+    }
+
+    @Override
+    public String read(JsonReader in) throws IOException {
+        if (in.peek().equals(JsonToken.NULL)) {
+            in.skipValue();
+            return "";
+        }
+
+        try {
+            return in.nextString();
+        } catch (NumberFormatException e) {
+            e.printStackTrace();
+            return "";
+        } catch (IOException e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ZGsonBuilder.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ZGsonBuilder.java
@@ -1,0 +1,43 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.GsonBuilder;
+import com.zhouyou.http.utils.Utils;
+
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class ZGsonBuilder {
+
+    public static <T> GsonBuilder gsonBuilder() {
+        return new GsonBuilder()
+                .registerTypeAdapterFactory(new ZTypeAdapterFactory())
+                .excludeFieldsWithModifiers(Modifier.FINAL, Modifier.TRANSIENT, Modifier.STATIC)
+                .serializeNulls();
+    }
+
+    public static <T> GsonBuilder gsonBuilder2(Type type) {
+        final Class<T> clazz = Utils.getClass(type, 0);
+        GsonBuilder gsonBuilder = new GsonBuilder()
+                .excludeFieldsWithModifiers(Modifier.FINAL, Modifier.TRANSIENT, Modifier.STATIC)
+                .serializeNulls();
+        if (clazz.isAssignableFrom(List.class)) {
+            gsonBuilder.registerTypeHierarchyAdapter(clazz, new ListJsonDeserializer());
+        } else if (clazz.equals(Integer.class) || clazz.equals(int.class)
+                || clazz.equals(Boolean.class) || clazz.equals(boolean.class)
+                || clazz.equals(Byte.class) || clazz.equals(byte.class)
+                || clazz.equals(Character.class) || clazz.equals(char.class)
+                || clazz.equals(Double.class) || clazz.equals(double.class)
+                || clazz.equals(Float.class) || clazz.equals(float.class)
+                || clazz.equals(Long.class) || clazz.equals(long.class)
+                || clazz.equals(Short.class) || clazz.equals(short.class)
+                || clazz.equals(String.class)
+        ) {
+            gsonBuilder.registerTypeAdapterFactory(new ZTypeAdapterFactory());
+        } else {
+            gsonBuilder.registerTypeHierarchyAdapter(clazz, new ObjectJsonDeserializer<T>());
+        }
+        return gsonBuilder;
+    }
+
+}

--- a/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ZTypeAdapterFactory.java
+++ b/rxeasyhttp/src/main/java/com/zhouyou/http/gson/ZTypeAdapterFactory.java
@@ -1,0 +1,47 @@
+package com.zhouyou.http.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+class ZTypeAdapterFactory implements TypeAdapterFactory {
+    @SuppressWarnings("unchecked")
+    @Override
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        Class<T> rawType = (Class<T>) type.getRawType();
+        if (rawType.equals(Integer.class) || rawType.equals(int.class)) {
+            return (TypeAdapter<T>) new IntegerTypeAdapter();
+        } else if (rawType.equals(Float.class) || rawType.equals(float.class)) {
+            return (TypeAdapter<T>) new FloatTypeAdapter();
+        } else if  (rawType.equals(Double.class) || rawType.equals(double.class) || rawType.equals(Number.class)) {
+            return (TypeAdapter<T>) new DoubleTypeAdapter();
+        } else if  (rawType.equals(Boolean.class) || rawType.equals(boolean.class)) {
+            return (TypeAdapter<T>) new BoolTypeAdapter();
+        } else if  (rawType.equals(Character.class) || rawType.equals(char.class)) {
+            return (TypeAdapter<T>) new ChatTypeAdapter();
+        } else if  (rawType.equals(Byte.class) || rawType.equals(byte.class)) {
+            return (TypeAdapter<T>) new ByteTypeAdapter();
+        } else if  (rawType.equals(Long.class) || rawType.equals(long.class)) {
+            return (TypeAdapter<T>) new LongTypeAdapter();
+        } else if  (rawType.equals(Short.class) || rawType.equals(short.class)) {
+            return (TypeAdapter<T>) new ShortTypeAdapter();
+        } else if  (rawType.equals(String.class)) {
+            return (TypeAdapter<T>) new StringTypeAdapter();
+        } else if (rawType.equals(BigDecimal.class)) {
+            return (TypeAdapter<T>) new BigDecimalTypeAdapter();
+        } else if (rawType.equals(BigInteger.class)) {
+            return (TypeAdapter<T>) new BigIntegerTypeAdapter();
+        }
+//        else if  (rawType.equals(List.class)) {
+//            return (TypeAdapter<T>) new ListTypeAdapter();
+//        }
+//        else {
+//            return new ObjectTypeAdapter(rawType);
+//        }
+        return null;
+    }
+}

--- a/rxeasyhttp/src/main/res/values-ja-rJP/strings.xml
+++ b/rxeasyhttp/src/main/res/values-ja-rJP/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">rxeasyhttp</string>
+
+    <string name="parsing_error">解析エラー</string>
+    <string name="type_conversion_error">型変換エラー</string>
+    <string name="connection_failed">接続に失敗しました</string>
+    <string name="certificate_verification_failed">証明書の検証に失敗しました</string>
+    <string name="time_out">接続がタイムアウトしました</string>
+    <string name="cannot_be_resolved">ドメイン名を解決できません</string>
+    <string name="unknown_error">不明な間違い</string>
+</resources>

--- a/rxeasyhttp/src/main/res/values-zh-rCN/strings.xml
+++ b/rxeasyhttp/src/main/res/values-zh-rCN/strings.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">rxeasyhttp</string>
+
+    <string name="parsing_error">解析错误</string>
+    <string name="type_conversion_error">类型转换错误</string>
+    <string name="connection_failed">连接失败</string>
+    <string name="certificate_verification_failed">证书验证失败</string>
+    <string name="time_out">连接超时</string>
+    <string name="cannot_be_resolved">无法解析该域名</string>
+    <string name="unknown_error">未知错误</string>
+</resources>

--- a/rxeasyhttp/src/main/res/values/strings.xml
+++ b/rxeasyhttp/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">rxeasyhttp</string>
+    <string name="parsing_error">Parsing error</string>
+    <string name="type_conversion_error">Type conversion error</string>
+    <string name="connection_failed">Connection failed</string>
+    <string name="certificate_verification_failed">Certificate verification failed</string>
+    <string name="time_out">Connection timed out</string>
+    <string name="cannot_be_resolved">The domain name cannot be resolved</string>
+    <string name="unknown_error">Unknown</string>
 </resources>


### PR DESCRIPTION
1，增加国际化，目前可用的英语，汉语和日语。
2，修改ApiResultFunc类，一定程度解决了请求成功和失败的时候，数据返回不同类型导致Gson解决错误的问题，例如：
请求成功时
{code ：0，message：“请求成功”，data：{... json数据...} }
请求失败时
{code：0，message：“请求失败”，data：“空” }
此解决方案是通过自定义Gson的TypeAdapter<T>来解析数据，当前只能适配到data一级，当以下数据结构时依然会报解析错误（当然这已经足够解决请求成功和失败的时候，数据data返回不同类型导致Gson解决错误的问题，还不影响自定义ApiResult）：
期待结构：
{code ：0，message：“请求成功”，data：{ "info": {} } }
服务器返回结构：
{code ：0，message：“请求成功”，data：{ "info": “” } }
